### PR TITLE
refactor(ci): split test targets into unit-test and e2e-test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
@@ -20,9 +20,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm nx run-many --targets=test --all --exclude=lobby-server-e2e
+      - run: pnpm nx run-many --targets=unit-test --all
 
-  e2e:
+  e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest
     services:
@@ -47,7 +47,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm e2e:lobby
+      - run: pnpm nx run-many --targets=e2e-test --all
         env:
           REDIS_URL: localhost
           REDIS_PORT: 6379

--- a/apps/lobby-server-e2e/project.json
+++ b/apps/lobby-server-e2e/project.json
@@ -4,6 +4,18 @@
   "root": "apps/lobby-server-e2e",
   "sourceRoot": "apps/lobby-server-e2e/src",
   "projectType": "application",
+  "targets": {
+    "e2e-test": {
+      "cache": true,
+      "inputs": ["default", "^default"],
+      "outputs": ["{workspaceRoot}/coverage/lobby-server-e2e"],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/lobby-server-e2e",
+        "command": "vitest run"
+      }
+    }
+  },
   "tags": ["type:e2e"],
   "implicitDependencies": ["lobby-server"]
 }

--- a/apps/lobby-server/project.json
+++ b/apps/lobby-server/project.json
@@ -62,7 +62,7 @@
       "dependsOn": ["prune-lockfile", "copy-workspace-modules"],
       "executor": "nx:noop"
     },
-    "test": {
+    "unit-test": {
       "executor": "@nx/vitest:test",
       "outputs": ["{workspaceRoot}/coverage/lobby-server"],
       "options": {

--- a/nx.json
+++ b/nx.json
@@ -8,7 +8,10 @@
     "build": {
       "dependsOn": ["^build"]
     },
-    "test": {
+    "unit-test": {
+      "inputs": ["default", "^default"]
+    },
+    "e2e-test": {
       "inputs": ["default", "^default"]
     },
     "lint": {
@@ -41,7 +44,7 @@
       "plugin": "@nx/vite/plugin",
       "options": {
         "buildTargetName": "build",
-        "testTargetName": "test",
+        "testTargetName": "unit-test",
         "serveTargetName": "serve",
         "devTargetName": "dev",
         "previewTargetName": "preview",
@@ -49,14 +52,16 @@
         "typecheckTargetName": "typecheck",
         "buildDepsTargetName": "build-deps",
         "watchDepsTargetName": "watch-deps"
-      }
+      },
+      "exclude": ["apps/lobby-server-e2e/**"]
     },
     {
       "plugin": "@nx/vitest",
       "options": {
-        "testTargetName": "test",
-        "ciTargetName": "test-ci"
-      }
+        "testTargetName": "unit-test",
+        "ciTargetName": "unit-test-ci"
+      },
+      "exclude": ["apps/lobby-server-e2e/**"]
     },
     {
       "plugin": "@nx/eslint/plugin",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "scripts": {
     "web:dev": "nx dev web",
     "web:build": "nx build web",
-    "web:test": "nx test web",
+    "web:test": "nx unit-test web",
     "p2p:dev": "nx serve lobby-server",
     "p2p:build": "nx build lobby-server",
-    "e2e:lobby": "nx test lobby-server-e2e",
-    "e2e:lobby:coverage": "nx test lobby-server-e2e --coverage",
+    "e2e:lobby": "nx e2e-test lobby-server-e2e",
+    "e2e:lobby:coverage": "nx e2e-test lobby-server-e2e --coverage",
     "verify": "nx run-many --targets=lint,build --all",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary

- Rename Nx test targets: `test` → `unit-test` for unit tests, `e2e-test` for e2e tests
- Configure `@nx/vite` and `@nx/vitest` plugins to exclude `lobby-server-e2e` from auto-generated `unit-test` targets
- Update CI workflow to use `nx run-many --targets=unit-test` and `nx run-many --targets=e2e-test`
- Update `package.json` scripts accordingly

This replaces the `--exclude=lobby-server-e2e` workaround with a proper target-based separation.

## Test plan

- [x] `nx run-many --targets=unit-test --all` runs 3 projects (lobby-server, shared-types, web)
- [x] `nx run-many --targets=e2e-test --all` runs 1 project (lobby-server-e2e)
- [x] `lobby-server-e2e` has no `unit-test` target